### PR TITLE
Fetch author data from Supabase

### DIFF
--- a/author.html
+++ b/author.html
@@ -89,7 +89,16 @@
     <a href="all-articles.html" class="btn-pill">View All Articles</a>
   </div>
 
+  <!-- Supabase client -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script>
+    const SUPABASE_URL = 'https://hnvcbrlyuytmawlpgaal.supabase.co';
+    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhudmNicmx5dXl0bWF3bHBnYWFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU1NDI5NTYsImV4cCI6MjA3MTExODk1Nn0.Ik4LauJ_QOJGOo9ZOCbxmyldyqVtJy_PfCt-2rH4hLw';
+    const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  </script>
+
+  <script>
+  (async function () {
     function slugifyName(name) {
       return (name || '')
         .toLowerCase()
@@ -102,11 +111,30 @@
     const raw = params.get('author') || '';
     const authorSlug = decodeURIComponent(raw).toLowerCase();
 
-    const authors = JSON.parse(localStorage.getItem('authors') || '{}');
-    const articles = JSON.parse(localStorage.getItem('articles') || '[]');
+    // Fetch author record
+    const { data: authorRow, error: authorError } = await supabase
+      .from('authors')
+      .select('*')
+      .eq('slug', authorSlug)
+      .single();
 
-    // Resolve author record
-    const author = authors[authorSlug] || null;
+    if (authorError) {
+      console.error('Error loading author:', authorError);
+    }
+
+    const author = authorRow || null;
+
+    // Fetch all articles (newest first)
+    const { data: rows, error: articlesError } = await supabase
+      .from('articles')
+      .select('*')
+      .order('timestamp', { ascending: false });
+
+    if (articlesError) {
+      console.error('Error loading articles:', articlesError);
+    }
+
+    const articles = rows || [];
 
     // Header elements
     const headerEl = document.getElementById('authorHeader');
@@ -118,62 +146,67 @@
 
     if (!author && !articles.length) {
       document.body.insertAdjacentHTML('afterbegin', '<p>No author or articles found.</p>');
-    } else {
-      // Show author header (fallback to inferred name if missing in registry)
-      const inferredName = (() => {
-        const any = articles.find(a => (a.authorSlug || slugifyName(a.author || '')) === authorSlug);
-        return any?.author || authorSlug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-      })();
-
-      const displayName = author?.name || inferredName;
-      const displayPhoto = author?.photo || 'images/author-placeholder.png';
-      const displayBio = author?.bio || '';
-
-      pageTitle.style.display = 'block';
-      pageTitle.textContent = displayName;
-
-      headerEl.style.display = 'grid';
-      photoEl.src = displayPhoto;
-      photoEl.alt = displayName;
-      nameEl.textContent = displayName;
-      bioEl.textContent = displayBio;
-
-      // List articles for this author (by authorSlug, fallback to name matching)
-      const filtered = articles.filter(a => {
-        const slug = a.authorSlug || slugifyName(a.author || '');
-        return slug === authorSlug;
-      }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-
-      if (!filtered.length) {
-        listEl.innerHTML = '<p>No articles by this author yet.</p>';
-      } else {
-        filtered.forEach(article => {
-          const tags = Array.isArray(article.tag) ? article.tag : (article.tag ? [article.tag] : []);
-          const pillsHTML = tags.map(t => {
-            const slug = String(t);
-            const label = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-            return \`<a class="tag-pill" href="tag.html?tag=\${encodeURIComponent(slug)}">\${label}</a>\`;
-          }).join('');
-
-          const dateStr = article.timestamp
-            ? new Date(article.timestamp).toLocaleDateString(undefined, { year:'numeric', month:'long', day:'numeric' })
-            : 'Unknown date';
-
-          const excerpt = (article.body || '').split(' ').slice(0, 40).join(' ');
-
-          const div = document.createElement('div');
-          div.className = 'article';
-          div.innerHTML = \`
-            <h2><a href="article.html?id=\${article.id}">\${article.title}</a></h2>
-            <div class="meta">Published \${dateStr}\${typeof article.views === 'number' ? \` — \${article.views} views\` : ''}</div>
-            \${tags.length ? \`<div class="tag-pills">\${pillsHTML}</div>\` : ''}
-            \${article.image ? \`<a href="article.html?id=\${article.id}"><img src="\${article.image}" alt="Image for \${article.title}" loading="lazy" style="max-width:100%;height:auto;margin:10px 0;"></a>\` : ''}
-            <p>\${excerpt}...</p>
-          \`;
-          listEl.appendChild(div);
-        });
-      }
+      return;
     }
+
+    // Show author header (fallback to inferred name if missing in registry)
+    const inferredName = (() => {
+      const any = articles.find(a => (a.author_slug || slugifyName(a.author || '')) === authorSlug);
+      return any?.author || authorSlug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    })();
+
+    const displayName = author?.name || inferredName;
+    const displayPhoto = author?.photo || 'images/author-placeholder.png';
+    const displayBio = author?.bio || '';
+
+    pageTitle.style.display = 'block';
+    pageTitle.textContent = displayName;
+
+    headerEl.style.display = 'grid';
+    photoEl.src = displayPhoto;
+    photoEl.alt = displayName;
+    nameEl.textContent = displayName;
+    bioEl.textContent = displayBio;
+
+    // List articles for this author (by author_slug, fallback to name matching)
+    const filtered = articles.filter(a => {
+      const slug = a.author_slug || slugifyName(a.author || '');
+      return slug === authorSlug;
+    }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+    if (!filtered.length) {
+      listEl.innerHTML = '<p>No articles by this author yet.</p>';
+      return;
+    }
+
+    filtered.forEach(article => {
+      const tags = Array.isArray(article.tags)
+        ? article.tags
+        : (Array.isArray(article.tag) ? article.tag : (article.tag ? [article.tag] : []));
+      const pillsHTML = tags.map(t => {
+        const slug = String(t);
+        const label = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        return \`<a class="tag-pill" href="tag.html?tag=\${encodeURIComponent(slug)}">\${label}</a>\`;
+      }).join('');
+
+      const dateStr = article.timestamp
+        ? new Date(article.timestamp).toLocaleDateString(undefined, { year:'numeric', month:'long', day:'numeric' })
+        : 'Unknown date';
+
+      const excerpt = (article.body || '').split(' ').slice(0, 40).join(' ');
+
+      const div = document.createElement('div');
+      div.className = 'article';
+      div.innerHTML = \`
+        <h2><a href="article.html?id=\${article.id}">\${article.title}</a></h2>
+        <div class="meta">Published \${dateStr}\${typeof article.views === 'number' ? \` — \${article.views} views\` : ''}</div>
+        \${tags.length ? \`<div class="tag-pills">\${pillsHTML}</div>\` : ''}
+        \${article.image ? \`<a href="article.html?id=\${article.id}"><img src="\${article.image}" alt="Image for \${article.title}" loading="lazy" style="max-width:100%;height:auto;margin:10px 0;"></a>\` : ''}
+        <p>\${excerpt}...</p>
+      \`;
+      listEl.appendChild(div);
+    });
+  })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Supabase client on author pages
- Query authors and articles from Supabase instead of localStorage
- Render author-specific article lists using Supabase results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c19b1eae6083299aa2e6631374e905